### PR TITLE
[SpringSecurityConfig] 파일 생성

### DIFF
--- a/src/main/kotlin/com/example/springsecurityjwt/configs/SpringSecurityConfig.kt
+++ b/src/main/kotlin/com/example/springsecurityjwt/configs/SpringSecurityConfig.kt
@@ -1,0 +1,50 @@
+package com.example.springsecurityjwt.configs
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.builders.WebSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+
+
+@Configuration
+@EnableWebSecurity
+class SpringSecurityConfig {
+
+    /**
+     * 인증/인가 검사를 수행하지 않도록 설정
+     */
+    @Bean
+    fun webSecurityCustomizer(): WebSecurityCustomizer {
+        return WebSecurityCustomizer { web: WebSecurity ->
+            web.ignoring().requestMatchers(
+                "/",
+                "/sign-up", // 회원가입 Endpoint
+                "/sign-in", // 로그인 Endpoint
+            )
+        }
+    }
+
+    @Bean
+    @Throws(Exception::class)
+    fun filterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .httpBasic().disable()
+            .csrf().disable()
+            .formLogin().disable()
+
+            // 그외 모든 경로는 어떤 식으로든 인증을 수행해야 한다
+            .authorizeHttpRequests {
+                it.requestMatchers("/**")
+                it.anyRequest().authenticated()
+            }
+
+            // 세션은 사용하지 않음
+            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+
+        return http.build()
+    }
+}


### PR DESCRIPTION
* spring security를 사용하기 위해 기본적인 설정 추가
* sign-up과 sign-in에 대해서는 인증 필터를 태우지 않음

close: #19