### PR TITLE
[Jwt] Jwt에서 사용할 Key생성

### DIFF
--- a/src/main/kotlin/com/example/springsecurityjwt/jwt/JwtKey.kt
+++ b/src/main/kotlin/com/example/springsecurityjwt/jwt/JwtKey.kt
@@ -1,0 +1,25 @@
+package com.example.springsecurityjwt.jwt
+
+object JwtKey {
+    private val JWT_KEY_SETS = JwtKeySets(
+        listOf(
+            JwtKeySets.JwtKeySet(
+                kid = "kid-1",
+                secretKey = "cxpoi2thr0w0gxgrz0w4yj59v7kk4sae",
+            ),
+            JwtKeySets.JwtKeySet(
+                kid = "kid-2",
+                secretKey = "oyuq98vmooc59h1iwfhb6kgczyt71p21",
+            ),
+            JwtKeySets.JwtKeySet(
+                kid = "kid-3",
+                secretKey = "lhfz5s7lhk5215l4gco26zioo5no5r3a",
+            ),
+        ),
+    )
+
+    fun getRandomJwtKeySet() = JWT_KEY_SETS.getRandomJwtKeySet()
+
+    fun getJwtKeySetByKid(kid: String) = JWT_KEY_SETS.getJwtKeySetByKid(kid)
+
+}

--- a/src/main/kotlin/com/example/springsecurityjwt/jwt/JwtKeySets.kt
+++ b/src/main/kotlin/com/example/springsecurityjwt/jwt/JwtKeySets.kt
@@ -1,0 +1,25 @@
+package com.example.springsecurityjwt.jwt
+
+import io.jsonwebtoken.security.Keys
+import java.nio.charset.StandardCharsets
+import java.security.Key
+import kotlin.random.Random
+
+data class JwtKeySets(
+    val jwtKeySets: List<JwtKeySet>,
+) {
+    data class JwtKeySet(
+        val kid: String,
+        val secretKey: String,
+    ) {
+        val signingKey: Key = Keys.hmacShaKeyFor(secretKey.toByteArray(StandardCharsets.UTF_8))
+    }
+
+    fun getRandomJwtKeySet(): JwtKeySet {
+        return jwtKeySets[Random.nextInt(jwtKeySets.size)]
+    }
+
+    fun getJwtKeySetByKid(kid: String): JwtKeySet? {
+        return jwtKeySets.singleOrNull { it.kid == kid }
+    }
+}

--- a/src/test/kotlin/com/example/springsecurityjwt/jwt/JwtKeySetsTest.kt
+++ b/src/test/kotlin/com/example/springsecurityjwt/jwt/JwtKeySetsTest.kt
@@ -1,0 +1,63 @@
+package com.example.springsecurityjwt.jwt
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+class JwtKeySetsTest {
+
+    @Test
+    fun `sut should get random secret key set`() {
+        // Arrange
+        val jwtKeySet1 = JwtKeySets.JwtKeySet(
+            kid = "kid-1",
+            secretKey = "x22dtga4s4lv4nn8t5m5i8peannyfxab",
+        )
+        val jwtKeySet2 = JwtKeySets.JwtKeySet(
+            kid = "kid-2",
+            secretKey = "x2tpjt382rlvugnvzntkt4lp3ws907bd",
+        )
+        val sut = JwtKeySets(listOf(jwtKeySet1, jwtKeySet2))
+
+        // Act
+        val randomSecretKeySet = sut.getRandomJwtKeySet()
+
+        // Assert
+        assertNotNull(randomSecretKeySet)
+        assertTrue(sut.jwtKeySets.contains(randomSecretKeySet))
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideKidsAndExpectedResults")
+    fun `sut should get secret key set when kid is given`(kid: String, expectedResult: String?) {
+        // Arrange
+        val jwtKeySet1 = JwtKeySets.JwtKeySet(
+            kid = "kid-1",
+            secretKey = "x22dtga4s4lv4nn8t5m5i8peannyfxab",
+        )
+        val jwtKeySet2 = JwtKeySets.JwtKeySet(
+            kid = "kid-2",
+            secretKey = "x2tpjt382rlvugnvzntkt4lp3ws907bd",
+        )
+        val sut = JwtKeySets(listOf(jwtKeySet1, jwtKeySet2))
+
+        // Act
+        val secretKeySet = sut.getJwtKeySetByKid(kid)
+
+        // Assert
+        assertEquals(expectedResult, secretKeySet?.kid)
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun provideKidsAndExpectedResults() = listOf(
+            arrayOf("kid-1", "kid-1"),
+            arrayOf("kid-2", "kid-2"),
+            arrayOf("non-existing-kid", null),
+        )
+    }
+}


### PR DESCRIPTION
* JWT 키는 유출되면 모든 데이터가 유출될 위험이 있기 때문에 여러 개의 키를 사용하여 accessToken을 만드는 key rolling기술을 사용한다
* `hmacShaKeyFor` 함수를 사용하기 위해서는 32byte(256bit)의 message가 필요하다
* 영어와 숫자는 1byte(8bit)이기 때문에 최소 32자를 지정해야한다

close: #23