### PR TITLE
[AuthenticationUtils] 인증 요청이 filter에서 온건지 sign in에서 온건지를 확인하기 위한 구분자 생성

### DIFF
--- a/src/main/kotlin/com/example/springsecurityjwt/utils/AuthenticationUtils.kt
+++ b/src/main/kotlin/com/example/springsecurityjwt/utils/AuthenticationUtils.kt
@@ -3,6 +3,7 @@ package com.example.springsecurityjwt.utils
 import com.example.springsecurityjwt.domains.Role
 
 object AuthenticationUtils {
+    const val AUTHENTICATION_PASSWORD_FROM_FILTER = "AUTHENTICATION_PASSWORD_FROM_FILTER"
     private const val USERNAME_ROLE_DELIMITER = "||"
 
     /**


### PR DESCRIPTION
* 이 구분자를 통해 필터에서 온 인증요청인지를 파악한다
* 필터에서 사용하는 인증을 위해 평문 비밀번호를 사용하려면 추가 서비스를 이용해야하지만 불필요하다고 판단하여 비밀번호 인증은 하지 않음

close: #65